### PR TITLE
Fix #8 Prevent mirroring tank health bar

### DIFF
--- a/Assets/Prefabs/Tank.prefab
+++ b/Assets/Prefabs/Tank.prefab
@@ -628,8 +628,8 @@ RectTransform:
   m_Father: {fileID: 224688316700543928}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.06, y: 0.342}
-  m_SizeDelta: {x: 8.702, y: -5.975}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00000047683716, y: 0.319}
+  m_SizeDelta: {x: 18.702, y: 4.025}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Scripts/Tank/TankBehavior.cs
+++ b/Assets/Scripts/Tank/TankBehavior.cs
@@ -36,6 +36,14 @@ namespace TankMania
             {
                 ControlMovement();
             }
+
+            { // Prevent the health bar from mirroring when tank turns
+                _slider.transform.localScale = new Vector3(
+                    Math.Abs(_slider.transform.localScale.x) * Math.Sign(this.transform.localScale.x),
+                    _slider.transform.localScale.y,
+                    _slider.transform.localScale.z
+                );
+            }
         }
 
         public void TakeCurrentTurn()

--- a/Assets/Scripts/Tank/TankBehavior2.cs
+++ b/Assets/Scripts/Tank/TankBehavior2.cs
@@ -27,9 +27,6 @@ namespace TankMania
                     transform.localScale.x * Mathf.Sign(moveH * transform.localScale.x),
                     transform.localScale.y
                 );
-
-                // Prevents the healthbar from mirroring when tank turns
-                _slider.SetDirection(transform.localScale.x > 0 ? Slider.Direction.RightToLeft : Slider.Direction.LeftToRight, true);
             }
 
             if (!_alreadyFired && Input.GetKey(FireKey))

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.3.0f3
+m_EditorVersion: 2017.3.1f1


### PR DESCRIPTION
- Centered health bar on x axis
- Checks happen on each frame

> Also, previous fix wasn't working when a tank is idle and gets shot.